### PR TITLE
Fix null ref bug if heart doesn't exist

### DIFF
--- a/Assets/- Scripts/Player/State/State.cs
+++ b/Assets/- Scripts/Player/State/State.cs
@@ -102,10 +102,10 @@ namespace Player
             _sm.flingInput.performed -= OnPlayerStartCharge;
             _sm.flingInput.canceled -= OnPlayerFinishCharge;
             _sm.hitTracker.ChangeHealthEvent -= OnChangeHealth;
-            _sm.heart.health.ChangeHealthEvent -= OnChangeHealth;
 
             if (_sm.heart)
             {
+                _sm.heart.health.ChangeHealthEvent -= OnChangeHealth;
                 _sm.heart.LandedEvent -= OnHeartLanded;
             }
 


### PR DESCRIPTION
* Tutorial Player should no longer get null dereference bugs if the heart is not set.