### PR TITLE
Pacifism

### DIFF
--- a/Assets/Input/PlayerInput.cs
+++ b/Assets/Input/PlayerInput.cs
@@ -76,39 +76,6 @@ public partial class @PlayerInput : IInputActionCollection2, IDisposable
             ""bindings"": [
                 {
                     ""name"": """",
-                    ""id"": ""6bd3867b-5b5b-41ac-9ac0-a657bb676684"",
-                    ""path"": ""<Gamepad>/buttonWest"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Gamepad"",
-                    ""action"": ""Attack"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""947952b2-2317-4f74-bc1d-28b6bb3111c1"",
-                    ""path"": ""<Mouse>/leftButton"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Keyboard Mouse"",
-                    ""action"": ""Attack"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
-                    ""id"": ""74e83d89-047d-45f2-b4dc-bc8d64e5ecfe"",
-                    ""path"": ""<Keyboard>/j"",
-                    ""interactions"": """",
-                    ""processors"": """",
-                    ""groups"": ""Keyboard Mouse"",
-                    ""action"": ""Attack"",
-                    ""isComposite"": false,
-                    ""isPartOfComposite"": false
-                },
-                {
-                    ""name"": """",
                     ""id"": ""ab4e6c91-6414-42da-a4ff-1cd45a396085"",
                     ""path"": ""<Gamepad>/buttonSouth"",
                     ""interactions"": """",

--- a/Assets/Input/PlayerInput.inputactions
+++ b/Assets/Input/PlayerInput.inputactions
@@ -54,39 +54,6 @@
             "bindings": [
                 {
                     "name": "",
-                    "id": "6bd3867b-5b5b-41ac-9ac0-a657bb676684",
-                    "path": "<Gamepad>/buttonWest",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Gamepad",
-                    "action": "Attack",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "947952b2-2317-4f74-bc1d-28b6bb3111c1",
-                    "path": "<Mouse>/leftButton",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard Mouse",
-                    "action": "Attack",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "74e83d89-047d-45f2-b4dc-bc8d64e5ecfe",
-                    "path": "<Keyboard>/j",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "Keyboard Mouse",
-                    "action": "Attack",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "ab4e6c91-6414-42da-a4ff-1cd45a396085",
                     "path": "<Gamepad>/buttonSouth",
                     "interactions": "",


### PR DESCRIPTION
Remove attack control bindings
Note: No code has been changed aside from the input settings. The player is just no longer able to execute an attack.