### PR TITLE
Victory & Transition fixes

### DIFF
--- a/Assets/- Scripts/Levels/VictoryTrigger.cs
+++ b/Assets/- Scripts/Levels/VictoryTrigger.cs
@@ -5,8 +5,16 @@ using UnityEngine;
 /// </summary>
 public class VictoryTrigger : MonoBehaviour
 {
+    private bool triggered;
     private void OnTriggerEnter(Collider coll)
     {
-        if (coll.gameObject.CompareTag("Player")) { TransitionManager.TransitionToNextScene(); }
+        if (triggered) { return; }
+
+        triggered = true;
+
+        if (coll.gameObject.tag is "Player" or "Heart")
+        {
+            TransitionManager.TransitionToNextScene();
+        }
     }
 }

--- a/Assets/- Scripts/TransitionManager.cs
+++ b/Assets/- Scripts/TransitionManager.cs
@@ -135,8 +135,8 @@ public class TransitionManager : MonoBehaviour {
             .Append(_screenFadeOverlay.DOFade(endValue: 1, duration: fadeTime)
                 .OnComplete(() =>
                 {
-                    SceneManager.LoadSceneAsync(sceneName);
                     FadeoutFinishEvent?.Invoke();
+                    SceneManager.LoadSceneAsync(sceneName);
                 }))
             
             // wait a little bit

--- a/Assets/- Scripts/UI/Comics/ComicManager.cs
+++ b/Assets/- Scripts/UI/Comics/ComicManager.cs
@@ -83,6 +83,7 @@ public class ComicManager : MonoBehaviour
 
         // clean up event subscriptions
         TransitionManager.FadeinFinishEvent -= SetupInput;
+        TransitionManager.FadeoutFinishEvent -= HideEverything;
 
         // teardown input and input events
         TeardownInput();


### PR DESCRIPTION
* `VictoryTrigger` can be hit by Dodger, not just Kitty
* `VictoryTrigger` can no longer trigger multiple times sequentially
* Add missing event unsubscription in `ComicManager`