### PR TITLE
Fix position of CK2 Checkpoint

### DIFF
--- a/Assets/- Scenes/MainGame/2) Cat Kingdom/Kingdom 2.unity
+++ b/Assets/- Scenes/MainGame/2) Cat Kingdom/Kingdom 2.unity
@@ -16820,32 +16820,32 @@ PrefabInstance:
     - target: {fileID: 801892640865637816, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 10.3
+      value: 18.04
       objectReference: {fileID: 0}
     - target: {fileID: 801892640865637816, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19.8
+      value: 20.95
       objectReference: {fileID: 0}
     - target: {fileID: 801892640865637816, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 3.44
+      value: -2.3
       objectReference: {fileID: 0}
     - target: {fileID: 801892641244727422, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.9
+      value: 15.25
       objectReference: {fileID: 0}
     - target: {fileID: 801892641244727422, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 18.54
+      value: 20.86
       objectReference: {fileID: 0}
     - target: {fileID: 801892641244727422, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 3.44
+      value: -0.59
       objectReference: {fileID: 0}
     - target: {fileID: 1837330698145701706, guid: 9a29deba33daac14cac9be10ddf2d735,
         type: 3}
@@ -25795,7 +25795,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-13452
+  m_Name: pb_Mesh-510266
   serializedVersion: 11
   m_SubMeshes:
   - serializedVersion: 2


### PR DESCRIPTION
* Initial checkpoint of CK2 was placed such that the player would get stuck under the platform once it got into place. Moved it forward a bit and now it works fine.